### PR TITLE
Added a workflow to send release notes to support system.

### DIFF
--- a/.github/workflows/send-changelog.yml
+++ b/.github/workflows/send-changelog.yml
@@ -1,0 +1,21 @@
+name: Send release notes to Support
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Send release data to server
+        run: |
+          curl -X POST https://support.amplify-b2b.com/api/changelog \
+          -H "Content-Type: application/json" \
+          -d '{
+            "tag_name": "${{ github.event.release.tag_name }}",
+            "name": "${{ github.event.release.name }}",
+            "body": ${{ toJson(github.event.release.body) }},
+            "html_url": "${{ github.event.release.html_url }}",
+            "created_at": "${{ github.event.release.created_at }}",
+            "published_at": "${{ github.event.release.published_at }}",
+            "author": "${{ github.event.release.author.login }}",
+            "repo": "${{ github.repository }}"
+          }'


### PR DESCRIPTION
This PR will introduce a workflow that will send the release notes all the changes happen in between previous and these release into a remote server while we will track down all the individual repository changes into in every day to track down changes