### PR TITLE
Fixed contact edit issue and approving customer once the contact is approved

### DIFF
--- a/src/Http/Controllers/Admin/ContactRegistrationCrudController.php
+++ b/src/Http/Controllers/Admin/ContactRegistrationCrudController.php
@@ -203,7 +203,7 @@ class ContactRegistrationCrudController extends BackpackCustomCrudController
                 'type' => 'text',
                 'tab' => 'Basic',
                 'wrapper' => ['class' => 'form-group col-md-3'],
-            ]
+            ],
         ]);
 
         CRUD::addField([
@@ -212,7 +212,7 @@ class ContactRegistrationCrudController extends BackpackCustomCrudController
             'type' => 'select2_from_ajax_multiple',
             'placeholder' => 'Select Roles',
             'minimum_input_length' => 0,
-            'data_source' => route('contact.roles'),
+            'data_source' => backpack_url('contact/fetch/roles'),
             'include_all_form_fields' => true,
             'dependencies' => ['customer_id'],
             'tab' => 'Basic',
@@ -443,6 +443,10 @@ class ContactRegistrationCrudController extends BackpackCustomCrudController
             $contact->contactLogins()
                 ->where('customer_id', '<>', $contact->customer_id)
                 ->delete();
+
+            $contact->customer()->update([
+                'approved' => true,
+            ]);
 
             foreach ($request->contactLogins ?? [] as $login_customer) {
 

--- a/src/Http/Controllers/Admin/ContactRegistrationCrudController.php
+++ b/src/Http/Controllers/Admin/ContactRegistrationCrudController.php
@@ -189,6 +189,13 @@ class ContactRegistrationCrudController extends BackpackCustomCrudController
             ],
         ]);
 
+        CRUD::addField([
+            'name' => 'email',
+            'label' => 'Email',
+            'tab' => 'Basic',
+            'type' => 'email',
+        ]);
+
         CRUD::addFields([
             [
                 'name' => 'phone',
@@ -374,11 +381,6 @@ class ContactRegistrationCrudController extends BackpackCustomCrudController
     {
         // Get the contact entry
         $contact = Contact::findOrFail($request->id);
-        if ((bool)$contact->customer->approved == Customer::UNAPPROVED) {
-            throw ValidationException::withMessages([
-                'customer_id' => __('The contact\'s customer is not approved. Please approve the customer before enabling the contact.'),
-            ]);
-        }
 
         $this->crud->removeFields(['roles', 'contactLogins']);
         $this->crud->setRequest($this->crud->validateRequest());

--- a/src/Http/Requests/ContactRequest.php
+++ b/src/Http/Requests/ContactRequest.php
@@ -80,24 +80,26 @@ class ContactRequest extends FormRequest
     protected function prepareForValidation()
     {
         $roles = [];
+        $inputRoles = ! empty($this->input('roles')) ? $this->input('roles') : [];
+        $inputPermissions = ! empty($this->input('permissions')) ? $this->input('permissions') : [];
 
         if (config('permission.teams')) {
-            foreach ($this->input('roles', []) as $role) {
+            foreach ($inputRoles as $role) {
                 $roles[$role]['team_id'] = $this->input('customer_id');
             }
         } else {
-            $roles = $this->input('roles', []);
+            $roles = $inputRoles;
         }
 
 
         $permissions = [];
 
         if (config('permission.teams')) {
-            foreach ($this->input('permissions', []) as $permission) {
+            foreach ($inputPermissions as $permission) {
                 $permissions[$permission]['team_id'] = $this->input('customer_id');
             }
         } else {
-            $permissions = $this->input('permissions', []);
+            $permissions = $inputPermissions;
         }
 
         $this->merge([


### PR DESCRIPTION
### Summary

This PR fixes issues related to contact updates and improves the customer approval workflow.

### Changes

* Fixed the contact edit issue in the admin contact registration flow.
* Added the missing email field in the update operation.
* Updated the roles AJAX endpoint to use the correct Backpack route.
* Removed the validation restriction that prevented updating a contact when the related customer was not approved.
* Automatically approves the related customer once a contact is approved/updated.
* Fixed update errors occurring when `permission.php` has `teams` configuration enabled.
* Improved role and permission preparation logic by safely handling empty inputs during validation.

### Technical Details

* Updated `ContactRegistrationCrudController`:

  * Added email field to update form.
  * Fixed roles data source route.
  * Removed unnecessary customer approval validation block.
  * Added automatic customer approval update logic.

* Updated `ContactRequest`:

  * Refactored role and permission preparation logic.
  * Added safe handling for empty `roles` and `permissions` inputs when `permission.teams` is enabled.

### Impact

* Contacts can now be updated correctly without approval-related blocking issues.
* Customer approval status stays synchronized with approved contacts.
* Prevents update exceptions in team-based permission setups.
* Improves stability of contact update and permission assignment flows. 