### PR TITLE
The roles in the account request

### DIFF
--- a/src/Http/Controllers/Admin/ContactCrudController.php
+++ b/src/Http/Controllers/Admin/ContactCrudController.php
@@ -375,7 +375,7 @@ class ContactCrudController extends BackpackCustomCrudController
                 'include_all_form_fields' => true,
                 'dependencies' => ['customer_id'],
                 'tab' => 'Permission',
-                'nullable' => config('amplify.basic.is_permission_system_enabled'),
+                'nullable' => !config('amplify.basic.is_permission_system_enabled'),
             ],
             [ // select2_from_ajax: 1-n relationship
                 'label' => 'Address', // Table column heading

--- a/src/Http/Controllers/Admin/ContactRegistrationCrudController.php
+++ b/src/Http/Controllers/Admin/ContactRegistrationCrudController.php
@@ -221,9 +221,11 @@ class ContactRegistrationCrudController extends BackpackCustomCrudController
             'placeholder' => 'Select Roles',
             'minimum_input_length' => 0,
             'data_source' => backpack_url('contact/fetch/roles'),
+            'method' => 'POST',
             'include_all_form_fields' => true,
             'dependencies' => ['customer_id'],
             'tab' => 'Basic',
+            'nullable' => !config('amplify.basic.is_permission_system_enabled'),
         ]);
 
         CRUD::addField([ // select2_from_ajax: 1-n relationship


### PR DESCRIPTION


### What changed

* Changed the AJAX role field configuration method to use **POST** instead of the previous method.
* Updated the nullable logic to:

  ```php
  'nullable' => !config('amplify.basic.is_permission_system_enabled')
  ```
* Applied the same nullable logic update in `ContactCrudController` role field setup.

---

### Files touched

* `ContactCrudController.php`
* *(If included in your branch)* `ContactRegistrationCrudController.php`

---

### Why this change was made

* Switching to **POST** for role fetching aligns with backend endpoint expectations and helps avoid request/middleware inconsistencies.
* The previous nullable logic did not correctly reflect permission system behavior.

---

### Final behavior after update

* **Permission system enabled:** roles are **not nullable** (required)
* **Permission system disabled:** roles are **nullable** (optional)
