### PR TITLE
Fix state dropdown not showing selected value on customer and address forms

### DIFF
--- a/resources/views/fields/select2_state.blade.php
+++ b/resources/views/fields/select2_state.blade.php
@@ -1,0 +1,234 @@
+{{-- State select2 from ajax (stores iso2 in customers.state / customer_addresses.state) --}}
+@php
+    $connected_entity = new $field['model'];
+    $connected_entity_key_name = 'iso2';
+    $old_value = old_empty_or_null($field['name'], false) ?? $field['value'] ?? $field['default'] ?? false;
+
+    // Backpack sets BelongsTo entity field values to the related model id; we store iso2 in customers.state.
+    if (isset($field['entity']) && $crud->entry && $old_value && ! is_object($old_value)) {
+        $related = $crud->entry->{$field['entity']};
+
+        if ($related && (string) $related->getKey() === (string) $old_value) {
+            $old_value = $related->{$connected_entity_key_name};
+        }
+    }
+
+    if (! $old_value && $crud->entry?->{$field['name']}) {
+        $old_value = $crud->entry->{$field['name']};
+    }
+
+    $field['delay'] = $field['delay'] ?? 500;
+    $field['allows_null'] = $field['allows_null'] ?? $crud->model::isColumnNullable($field['name']);
+    $field['placeholder'] = $field['placeholder'] ?? trans('backpack::crud.select_entry');
+    $field['attribute'] = $field['attribute'] ?? 'name';
+    $field['minimum_input_length'] = $field['minimum_input_length'] ?? 0;
+
+    $item = null;
+
+    if (is_object($old_value)) {
+        $item = $old_value;
+    } elseif ($old_value) {
+        if (isset($field['entity']) && $crud->entry) {
+            $related = $crud->entry->{$field['entity']};
+
+            if ($related && $related->{$connected_entity_key_name} === $old_value) {
+                $item = $related;
+            }
+        }
+
+        if (! $item) {
+            $item = $connected_entity->where($connected_entity_key_name, $old_value)->first();
+
+            if (! $item && isset($field['dependencies'])) {
+                $query = $connected_entity->where($connected_entity_key_name, $old_value);
+
+                foreach (Arr::wrap($field['dependencies']) as $dependency) {
+                    $dependencyValue = old($dependency) ?? ($crud->entry?->{$dependency} ?? null);
+
+                    if ($dependencyValue) {
+                        $query->where($dependency, $dependencyValue);
+                    }
+                }
+
+                $item = $query->first();
+            }
+        }
+    }
+@endphp
+
+@include('crud::fields.inc.wrapper_start')
+    <label>{!! $field['label'] !!}</label>
+    <select
+        name="{{ $field['name'] }}"
+        style="width: 100%"
+        data-init-function="bpFieldInitSelect2StateElement"
+        data-field-is-inline="{{ var_export($inlineCreate ?? false) }}"
+        data-column-nullable="{{ var_export($field['allows_null']) }}"
+        data-dependencies="{{ isset($field['dependencies']) ? json_encode(Arr::wrap($field['dependencies'])) : json_encode([]) }}"
+        data-placeholder="{{ $field['placeholder'] }}"
+        data-minimum-input-length="{{ $field['minimum_input_length'] }}"
+        data-data-source="{{ $field['data_source'] }}"
+        data-method="{{ $field['method'] ?? 'GET' }}"
+        data-field-attribute="{{ $field['attribute'] }}"
+        data-connected-entity-key-name="{{ $connected_entity_key_name }}"
+        data-include-all-form-fields="{{ isset($field['include_all_form_fields']) ? ($field['include_all_form_fields'] ? 'true' : 'false') : 'false' }}"
+        data-ajax-delay="{{ $field['delay'] }}"
+        data-language="{{ str_replace('_', '-', app()->getLocale()) }}"
+        @include('crud::fields.inc.attributes', ['default_class' => 'form-control'])
+    >
+        @if ($item)
+            @if ($field['allows_null'])
+                <option value="">
+                    {{ $field['placeholder'] }}
+                </option>
+            @endif
+
+            <option value="{{ $item->{$connected_entity_key_name} }}" selected>
+                {{ $item->{$field['attribute']} }}
+            </option>
+        @endif
+    </select>
+
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+@include('crud::fields.inc.wrapper_end')
+
+@push('crud_fields_styles')
+    @loadOnce('packages/select2/dist/css/select2.min.css')
+    @loadOnce('packages/select2-bootstrap-theme/dist/select2-bootstrap.min.css')
+    @if ($field['allows_null'])
+        @loadOnce('select2_state_custom_css')
+        <style type="text/css">
+            .select2-selection__clear::after {
+                content: ' {{ trans('backpack::crud.clear') }}';
+            }
+        </style>
+        @endLoadOnce
+    @endif
+@endpush
+
+@push('crud_fields_scripts')
+    @loadOnce('packages/select2/dist/js/select2.full.min.js')
+    @if (app()->getLocale() !== 'en')
+        @loadOnce('packages/select2/dist/js/i18n/' . str_replace('_', '-', app()->getLocale()) . '.js')
+    @endif
+@endpush
+
+@push('crud_fields_scripts')
+@loadOnce('bpFieldInitSelect2StateElement')
+<script>
+    function bpFieldInitSelect2StateElement(element) {
+        var form = element.closest('form');
+        var $placeholder = element.attr('data-placeholder');
+        var $minimumInputLength = element.attr('data-minimum-input-length');
+        var $dataSource = element.attr('data-data-source');
+        var $method = element.attr('data-method');
+        var $fieldAttribute = element.attr('data-field-attribute');
+        var $connectedEntityKeyName = element.attr('data-connected-entity-key-name');
+        var $includeAllFormFields = element.attr('data-include-all-form-fields') == 'false' ? false : true;
+        var $allowClear = element.attr('data-column-nullable') == 'true' ? true : false;
+        var $dependencies = JSON.parse(element.attr('data-dependencies'));
+        var $ajaxDelay = element.attr('data-ajax-delay');
+        var $isFieldInline = element.data('field-is-inline');
+        var $fieldCleanName = element.attr('data-repeatable-input-name') ?? element.attr('name');
+
+        if ($(element).hasClass('select2-hidden-accessible')) {
+            return;
+        }
+
+        $(element).select2({
+            theme: 'bootstrap',
+            multiple: false,
+            placeholder: $placeholder,
+            minimumInputLength: $minimumInputLength,
+            allowClear: $allowClear,
+            dropdownParent: $isFieldInline ? $('#inline-create-dialog .modal-content') : $(document.body),
+            ajax: {
+                url: $dataSource,
+                type: $method,
+                dataType: 'json',
+                delay: $ajaxDelay,
+                data: function (params) {
+                    if ($includeAllFormFields) {
+                        return {
+                            q: params.term,
+                            page: params.page,
+                            form: form.serializeArray(),
+                            triggeredBy: {
+                                'rowNumber': element.attr('data-row-number') !== 'undefined' ? element.attr('data-row-number') - 1 : false,
+                                'fieldName': $fieldCleanName
+                            }
+                        };
+                    }
+
+                    return {
+                        q: params.term,
+                        page: params.page,
+                    };
+                },
+                processResults: function (data, params) {
+                    params.page = params.page || 1;
+
+                    let paginate = false;
+
+                    if (data.data) {
+                        paginate = data.next_page_url !== null;
+                        data = data.data;
+                    }
+
+                    return {
+                        results: $.map(data, function (item) {
+                            return {
+                                text: processStateItemText(item, $fieldAttribute),
+                                id: item[$connectedEntityKeyName],
+                            };
+                        }),
+                        pagination: {
+                            more: paginate,
+                        }
+                    };
+                },
+                cache: true
+            },
+        });
+
+        for (var i = 0; i < $dependencies.length; i++) {
+            var $dependency = $dependencies[i];
+
+            if (typeof element.attr('data-custom-selector') == 'undefined') {
+                form.find('[name="' + $dependency + '"], [name="' + $dependency + '[]"]').change(function () {
+                    $(element.find('option:not([value=""])')).remove();
+                    element.val(null).trigger('change');
+                });
+            } else {
+                let rowNumber = element.attr('data-row-number');
+                let selector = element.attr('data-custom-selector');
+
+                selector = selector
+                    .replaceAll('%DEPENDENCY%', $dependency)
+                    .replaceAll('%ROW%', rowNumber);
+
+                $(selector).change(function () {
+                    $(element.find('option:not([value=""])')).remove();
+                    element.val(null).trigger('change');
+                });
+            }
+        }
+    }
+
+    if (typeof processStateItemText !== 'function') {
+        function processStateItemText(item, $fieldAttribute) {
+            var $appLang = '{{ app()->getLocale() }}';
+            var $appLangFallback = '{{ Lang::getFallback() }}';
+            var $emptyTranslation = '{{ trans('backpack::crud.empty_translations') }}';
+            var $itemField = item[$fieldAttribute];
+
+            return typeof $itemField === 'object' && $itemField !== null
+                ? $itemField[$appLang] ? $itemField[$appLang] : $itemField[$appLangFallback] ? $itemField[$appLangFallback] : Object.values($itemField)[0] ? Object.values($itemField)[0] : $emptyTranslation
+                : $itemField;
+        }
+    }
+</script>
+@endLoadOnce
+@endpush

--- a/src/Http/Controllers/Admin/ContactRegistrationCrudController.php
+++ b/src/Http/Controllers/Admin/ContactRegistrationCrudController.php
@@ -8,12 +8,10 @@ use Amplify\System\Backend\Http\Requests\ContactRequest;
 use Amplify\System\Backend\Models\Contact;
 use Amplify\System\Backend\Models\ContactLogin;
 use Amplify\System\Backend\Models\Customer;
-use Amplify\System\Backend\Models\CustomerAddress;
 use Amplify\System\Backend\Models\CustomerGroup;
 use Amplify\System\Backend\Models\CustomerPermission;
 use Amplify\System\Backend\Models\Event;
 use Amplify\System\Factories\NotificationFactory;
-use Backpack\CRUD\app\Http\Controllers\Operations\CreateOperation;
 use Backpack\CRUD\app\Http\Controllers\Operations\DeleteOperation;
 use Backpack\CRUD\app\Http\Controllers\Operations\ListOperation;
 use Backpack\CRUD\app\Http\Controllers\Operations\ShowOperation;
@@ -21,7 +19,6 @@ use Backpack\CRUD\app\Http\Controllers\Operations\UpdateOperation;
 use Backpack\CRUD\app\Library\CrudPanel\CrudPanel;
 use Backpack\CRUD\app\Library\CrudPanel\CrudPanelFacade as CRUD;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Validation\ValidationException;
 
 /**
  * Class ContactRegistrationCrudController
@@ -30,7 +27,6 @@ use Illuminate\Validation\ValidationException;
  */
 class ContactRegistrationCrudController extends BackpackCustomCrudController
 {
-    use CreateOperation;
     use DeleteOperation;
     use ListOperation;
     use ShowOperation;
@@ -134,21 +130,14 @@ class ContactRegistrationCrudController extends BackpackCustomCrudController
      */
     protected function setupUpdateOperation()
     {
-        // Load the Contact model with the customer relationship
         $contact = Contact::with('customer')->findOrFail(request()->id);
-        // Set the customer ID in the form for the select2 field to pre-select the correct value
+
         $this->crud->entry = $contact; // Ensure the data is correctly set for the form
 
-        // This will set the customer team ID, just as you are already doing
-        set_customer_team_id($contact->customer->id);
+        set_customer_team_id($contact->customer_id);
 
-        // Call the setupCreateOperation method to apply the field configuration for the edit operation
         $this->crud->hasUploadFields();
         CRUD::setValidation(ContactRequest::class);
-
-        $attributes = request()->query()['category_name'] ?? false
-            ? ['readonly' => 'readonly']
-            : [];
 
         CRUD::addField([
             'label' => 'Customer', // Table column heading
@@ -172,32 +161,35 @@ class ContactRegistrationCrudController extends BackpackCustomCrudController
 
         CRUD::field('name')->type('text')->tab('Basic');
 
-        CRUD::addField([
-            'name' => 'accountTitle',
-            'label' => 'Account Title',
-            'tab' => 'Basic',
-            'type' => 'relationship',
-        ]);
-
-        CRUD::addField([
-            'name' => 'login_id',
-            'label' => 'Login ID',
-            'tab' => 'Basic',
-            'type' => 'text',
-            'attributes' => [
-                'autocomplete' => 'off',
-                'id' => 'new-account',
-            ],
-        ]);
-
-        CRUD::addField([
-            'name' => 'email',
-            'label' => 'Email',
-            'tab' => 'Basic',
-            'type' => 'email',
-        ]);
-
         CRUD::addFields([
+            [
+                'name' => 'account_title_id',
+                'label' => 'Account Title',
+                'tab' => 'Basic',
+                'type' => 'relationship',
+                'entity' => 'accountTitle',
+                'attribute' => 'name',
+            ],
+            [
+                'name' => 'email',
+                'label' => 'Email',
+                'tab' => 'Basic',
+                'type' => 'email',
+                'attributes' => [
+                    'autocomplete' => 'off',
+                    'id' => 'new-email-address',
+                ],
+            ],
+            [
+                'name' => 'login_id',
+                'label' => 'Login ID',
+                'tab' => 'Basic',
+                'type' => 'text',
+                'attributes' => [
+                    'autocomplete' => 'off',
+                    'id' => 'new-account',
+                ],
+            ],
             [
                 'name' => 'phone',
                 'label' => 'Phone',
@@ -212,42 +204,59 @@ class ContactRegistrationCrudController extends BackpackCustomCrudController
                 'tab' => 'Basic',
                 'wrapper' => ['class' => 'form-group col-md-3'],
             ],
+            [
+                'name' => 'roles',
+                'label' => 'Role(s)',
+                'type' => 'select2_from_ajax_multiple',
+                'placeholder' => 'Select Roles',
+                'minimum_input_length' => 0,
+                'data_source' => backpack_url('contact/fetch/roles'),
+                'method' => 'POST',
+                'include_all_form_fields' => true,
+                'dependencies' => ['customer_id'],
+                'tab' => 'Permission',
+                'nullable' => !config('amplify.basic.is_permission_system_enabled'),
+            ],
+            [ // select2_from_ajax: 1-n relationship
+                'label' => 'Address', // Table column heading
+                'type' => 'select2_from_ajax',
+                'name' => 'customer_address_id', // the column that contains the ID of that connected entity;
+                'model' => 'Amplify\System\Backend\Models\CustomerAddress', // the method that defines the relationship in your Model
+                'attribute' => 'display_name', // foreign key attribute that is shown to user
+                'data_source' => route('addresses.get'), // url to controller search function (with /{id} should return model)
+                'placeholder' => 'Select an address', // placeholder for the select
+                'include_all_form_fields' => true, // sends the other form fields along with the request so it can be filtered.
+                'minimum_input_length' => 0, // minimum characters to type before querying results
+                'dependencies' => ['customer_id'], // when a dependency changes, this select2 is reset to null
+                'pivot' => false,
+                'tab' => 'Basic',
+                'options' => (fn($query) => $query->orderBy('address_name')->get()),
+                'default' => old('customer_address_id', $this->crud->entry->customer_address_id ?? null),
+            ],
+            [
+                'name' => 'password',
+                'type' => 'toggle_password',
+                'view_namespace' => 'backend::fields',
+                'showButton' => 'true',
+                'tab' => 'Basic',
+                'attributes' => [
+                    'autocomplete' => 'off',
+                    'id' => 'new-password',
+                ],
+            ],
+            [
+                'name' => 'password_confirmation',
+                'type' => 'toggle_password',
+                'view_namespace' => 'backend::fields',
+                'label' => 'Retype Password',
+                'showButton' => 'true',
+                'tab' => 'Basic',
+                'attributes' => [
+                    'autocomplete' => 'off',
+                    'id' => 'new-password',
+                ],
+            ]
         ]);
-
-        CRUD::addField([
-            'name' => 'roles',
-            'label' => 'Role(s)',
-            'type' => 'select2_from_ajax_multiple',
-            'placeholder' => 'Select Roles',
-            'minimum_input_length' => 0,
-            'data_source' => backpack_url('contact/fetch/roles'),
-            'method' => 'POST',
-            'include_all_form_fields' => true,
-            'dependencies' => ['customer_id'],
-            'tab' => 'Basic',
-            'nullable' => !config('amplify.basic.is_permission_system_enabled'),
-        ]);
-
-        CRUD::addField([ // select2_from_ajax: 1-n relationship
-            'label' => 'Address', // Table column heading
-            'type' => 'select2_from_ajax',
-            'name' => 'customer_address_id', // the column that contains the ID of that connected entity;
-            'model' => CustomerAddress::class, // the method that defines the relationship in your Model
-            'attribute' => 'display_name', // foreign key attribute that is shown to user
-            'data_source' => route('addresses.get'), // url to controller search function (with /{id} should return model)
-            'placeholder' => 'Select an address', // placeholder for the select
-            'include_all_form_fields' => true, // sends the other form fields along with the request so it can be filtered.
-            'minimum_input_length' => 0, // minimum characters to type before querying results
-            'dependencies' => ['customer_id'], // when a dependency changes, this select2 is reset to null
-            'pivot' => false,
-            'tab' => 'Basic',
-            'options' => (fn ($query) => $query->orderBy('address_name')->get()),
-            'default' => old('customer_address_id', $this->crud->entry->customer_address_id ?? null),
-        ]);
-
-        CRUD::field('order_limit')->type('number')->attributes(['step' => 'any', 'min' => 0])->label('Order Limit')->tab('ERP');
-        CRUD::field('daily_budget_limit')->type('number')->attributes(['step' => 'any', 'min' => 0])->label('Daily Budget Limit')->tab('ERP');
-        CRUD::field('monthly_budget_limit')->type('number')->attributes(['step' => 'any', 'min' => 0])->label('Monthly Budget Limit')->tab('ERP');
 
         if (config('amplify.basic.enable_multi_customer_manage')) {
             CRUD::addField([
@@ -256,7 +265,7 @@ class ContactRegistrationCrudController extends BackpackCustomCrudController
                 'label' => 'Default Warehouse',
                 'entity' => 'ownWarehouse',
                 'tab' => 'ERP',
-                'options' => (fn ($query) => $query->orderBy('name')->get()),
+                'options' => (fn($query) => $query->orderBy('name')->get()),
             ]);
 
             CRUD::addField([
@@ -294,7 +303,7 @@ class ContactRegistrationCrudController extends BackpackCustomCrudController
                         'wrapper' => [
                             'class' => 'form-group col-md-6',
                         ],
-                        'options' => (fn ($query) => $query->orderBy('name')->get()),
+                        'options' => (fn($query) => $query->orderBy('name')->get()),
                     ],
                     [
                         'name' => 'customer_address_id',
@@ -305,7 +314,7 @@ class ContactRegistrationCrudController extends BackpackCustomCrudController
                         'wrapper' => [
                             'class' => 'form-group col-md-6',
                         ],
-                        'options' => (fn ($query) => $query->orderBy('address_name')->get()),
+                        'options' => (fn($query) => $query->orderBy('address_name')->get()),
                     ],
                     [
                         'name' => 'roles',
@@ -367,6 +376,16 @@ class ContactRegistrationCrudController extends BackpackCustomCrudController
         ]);
 
         CRUD::addField([
+            'name' => 'is_admin',
+            'label' => 'Is Admin',
+            'type' => 'boolean',
+            'allows_null' => false,
+            'default' => true,
+            'tab' => 'Basic',
+            'hint' => 'Note: A customer can have only one admin contact. To transfer admin, first uncheck this on the current admin and save, then check it on the new admin.',
+        ]);
+
+        CRUD::addField([
             'name' => 'ownPermissions',
             'label' => 'Permissions',
             'type' => 'permission',
@@ -377,6 +396,43 @@ class ContactRegistrationCrudController extends BackpackCustomCrudController
                     ->orderBy('name', 'ASC')->pluck('name', 'id')->toArray();
             },
             'tab' => 'Permission',
+        ]);
+
+        CRUD::modifyField('password', ['showAsterisk' => false]);
+        CRUD::modifyField('password_confirmation', ['showAsterisk' => false]);
+
+        CRUD::addField([
+            'name' => 'order_limit',
+            'type' => 'number',
+            'attributes' => [
+                'step' => 'any',
+                'min' => 0,
+            ],
+            'default' => '0',
+            'label' => 'Order Limit',
+            'tab' => 'ERP',
+        ]);
+        CRUD::addField([
+            'name' => 'daily_budget_limit',
+            'type' => 'number',
+            'attributes' => [
+                'step' => 'any',
+                'min' => 0,
+            ],
+            'default' => '0',
+            'label' => 'Daily Budget Limit',
+            'tab' => 'ERP',
+        ]);
+        CRUD::addField([
+            'name' => 'monthly_budget_limit',
+            'type' => 'number',
+            'attributes' => [
+                'step' => 'any',
+                'min' => 0,
+            ],
+            'default' => '0',
+            'label' => 'Monthly Budget Limit',
+            'tab' => 'ERP',
         ]);
     }
 

--- a/src/Http/Controllers/Admin/CustomerAddressCrudController.php
+++ b/src/Http/Controllers/Admin/CustomerAddressCrudController.php
@@ -179,7 +179,9 @@ class CustomerAddressCrudController extends BackpackCustomCrudController
                 'minimum_input_length' => 0,
                 'dependencies' => ['country_code'],
                 'name' => 'state',
-                'type' => 'select2_from_ajax',
+                'type' => 'select2_state',
+                'view_namespace' => 'backend::fields',
+                'entity' => 'stateModel',
                 'label' => 'State',
                 'wrapper' => [
                     'class' => 'form-group col-md-6',

--- a/src/Http/Controllers/Admin/CustomerCrudController.php
+++ b/src/Http/Controllers/Admin/CustomerCrudController.php
@@ -284,7 +284,9 @@ class CustomerCrudController extends BackpackCustomCrudController
                 'dependencies' => ['country_code'],
                 'tab' => 'Billing',
                 'name' => 'state',
-                'type' => 'select2_from_ajax',
+                'type' => 'select2_state',
+                'view_namespace' => 'backend::fields',
+                'entity' => 'billingState',
                 'label' => 'State',
                 'wrapper' => [
                     'class' => 'form-group col-md-6',


### PR DESCRIPTION
## Summary

- Add a scoped `select2_state` Backpack field that uses `states.iso2` as the option value, matching how `customers.state` and `customer_addresses.state` are stored
- Update `CustomerCrudController` and `CustomerAddressCrudController` to use the new field with their respective relationships (`billingState`, `stateModel`)
- Resolve selected state on edit by iso2 + `country_code`, and normalize Backpack’s BelongsTo `entity` behavior (which passes `states.id` instead of iso2)

## Problem

The state field used Backpack’s default `select2_from_ajax`, which expects the related model’s primary key (`states.id`). Our data stores the state **ISO2 code** (e.g. `UT`) in `customers.state` / `customer_addresses.state`, so the dropdown appeared empty on edit even when a state was saved.

## Solution

- Introduced `packages/backend/resources/views/fields/select2_state.blade.php`
- Switched customer and customer address forms from `select2_from_ajax` to `select2_state`
- Used model relationships for reliable lookup:
  - Customer: `entity => billingState`
  - Customer Address: `entity => stateModel`

## Files changed

- `packages/backend/resources/views/fields/select2_state.blade.php` (new)
- `packages/backend/src/Http/Controllers/Admin/CustomerCrudController.php`
- `packages/backend/src/Http/Controllers/Admin/CustomerAddressCrudController.php`