### PR TITLE
Set default customer currency from global currency config

### DIFF
--- a/src/Http/Controllers/Admin/CustomerCrudController.php
+++ b/src/Http/Controllers/Admin/CustomerCrudController.php
@@ -378,6 +378,7 @@ class CustomerCrudController extends BackpackCustomCrudController
             'type' => 'select2_from_array',
             'options' => UtilityHelper::currencyDropdown(),
             'allows_null' => false,
+            'default' => config('amplify.basic.global_currency'),
             'tab' => 'ERP Information',
         ]);
         CRUD::addField([


### PR DESCRIPTION
## Summary

- Pre-select the **Default Currency** field on the admin customer create/edit form using `config('amplify.basic.global_currency')`
- Aligns customer currency defaults with the existing site-wide currency setting (same pattern as `SitePricingCrudController`)

## Changes

- `packages/backend/src/Http/Controllers/Admin/CustomerCrudController.php`
  - Added `'default' => config('amplify.basic.global_currency')` to the `default_currency` field