### PR TITLE
Fix contact-login admin list and add Last Updated At to account requests

### DIFF
--- a/src/Http/Controllers/Admin/ContactCrudController.php
+++ b/src/Http/Controllers/Admin/ContactCrudController.php
@@ -265,6 +265,12 @@ class ContactCrudController extends BackpackCustomCrudController
             'type' => 'boolean',
         ]);
 
+        CRUD::addColumn([
+            'name' => 'updated_at',
+            'label' => 'Last Updated At',
+            'type' => 'datetime',
+        ]);
+
         $this->crud->addClause('approved');
 
         $this->crud->addButton('line', 'impersonate', 'view', 'backend::buttons.impersonate', 'end');

--- a/src/Http/Controllers/Admin/ContactLoginCrudController.php
+++ b/src/Http/Controllers/Admin/ContactLoginCrudController.php
@@ -69,11 +69,36 @@ class ContactLoginCrudController extends BackpackCustomCrudController
             $this->crud->addClause('where', 'created_at', '<=', $dates->to.' 23:59:59');
         });
 
-        CRUD::column('contact_id')->type('relationship');
-        CRUD::column('customer_id')->type('relationship');
-        CRUD::column('warehouse_id')->type('relationship');
-        CRUD::column('customer_address_id')->type('relationship');
-        CRUD::column('ship_to_name')->type('relationship');
+        CRUD::addColumn([
+            'name' => 'contact_id',
+            'type' => 'relationship',
+            'entity' => 'contact',
+            'attribute' => 'name',
+        ]);
+
+        CRUD::addColumn([
+            'name' => 'customer_id',
+            'type' => 'relationship',
+            'entity' => 'customer',
+            'attribute' => 'display_name',
+        ]);
+
+        CRUD::addColumn([
+            'name' => 'warehouse_id',
+            'type' => 'relationship',
+            'entity' => 'warehouse',
+            'attribute' => 'name',
+        ]);
+
+        CRUD::addColumn([
+            'name' => 'customer_address_id',
+            'label' => 'Customer address',
+            'type' => 'relationship',
+            'entity' => 'customerAddress',
+            'attribute' => 'display_name',
+        ]);
+
+        CRUD::column('ship_to_name');
         CRUD::column('last_logged_in')->type('datetime');
         CRUD::column('last_logged_out')->type('datetime');
         CRUD::column('created_at')->type('datetime');

--- a/src/Http/Controllers/Admin/ContactRegistrationCrudController.php
+++ b/src/Http/Controllers/Admin/ContactRegistrationCrudController.php
@@ -119,6 +119,11 @@ class ContactRegistrationCrudController extends BackpackCustomCrudController
                 return $phone;
             }
         ]);
+        CRUD::addColumn([
+            'name' => 'updated_at',
+            'label' => 'Last Updated At',
+            'type' => 'datetime',
+        ]);
     }
 
     /**


### PR DESCRIPTION
## Summary

- Fixes a crash on `/admin/contact-login` caused by Backpack Pro relationship columns missing `relation_type`
- Adds a **Last Updated At** column to the account requests list at `/admin/account-request`

## Changes

### ContactLoginCrudController

- Replaces fluent `CRUD::column()->type('relationship')` definitions with `CRUD::addColumn([...])` so Backpack correctly sets `relation_type` for relationship columns
- Maps `customer_address_id` to the `customerAddress` relationship with `display_name` as the display attribute (model method is camelCase, not `customer_address()`)
- Renders `ship_to_name` as a plain text column instead of a relationship column

### ContactRegistrationCrudController

- Adds a **Last Updated At** datetime column to the account requests list
- Uses the correct Eloquent field `updated_at` (initial implementation used `update_at`, which does not exist on the `contacts` table)