### PR TITLE
feat(contact-login): Session tracking, admin CRUD updates, and dashboard widget

### DIFF
--- a/database/migrations/2026_07_01_000001_add_session_tracking_to_contact_logins_table.php
+++ b/database/migrations/2026_07_01_000001_add_session_tracking_to_contact_logins_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('contact_logins', function (Blueprint $table) {
+            $table->enum('row_type', ['assignment', 'session'])
+                ->default('assignment')
+                ->after('id');
+            $table->nullableMorphs('impersonate');
+
+            $table->index(['contact_id', 'row_type']);
+            $table->index(['contact_id', 'row_type', 'last_logged_out'], 'contact_logins_open_sessions_index');
+        });
+
+        DB::table('contact_logins')->update(['row_type' => 'assignment']);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('contact_logins', function (Blueprint $table) {
+            $table->dropIndex('contact_logins_open_sessions_index');
+            $table->dropIndex(['contact_id', 'row_type']);
+            $table->dropMorphs('impersonate');
+            $table->dropColumn('row_type');
+        });
+    }
+};

--- a/resources/views/partials/contact-login-history.blade.php
+++ b/resources/views/partials/contact-login-history.blade.php
@@ -1,10 +1,11 @@
 @php
-    $contactLogins = $contact->contactLogins ?? collect();
+    $contactLogins = $contact->sessionLogins ?? collect();
 @endphp
 <table class="table table-bordered table-striped mb-0">
     <thead>
     <tr>
         <th>Customer</th>
+        <th>Initiated By</th>
         <th>Last Logged At</th>
         <th>Last Logged Out</th>
     </tr>
@@ -13,12 +14,13 @@
     @forelse($contactLogins as $entry)
         <tr>
             <td>{{ $entry->customer->customer_name ?? 'N/A' }}({{ $entry->customer->customer_code ?? 'N/A' }})</td>
+            <td>{{ $entry->getImpersonatorDisplayName() }}</td>
             <td>{{ carbon_datetime($entry->last_logged_in) }}</td>
             <td>{{ carbon_datetime($entry->last_logged_out) }}</td>
         </tr>
     @empty
         <tr>
-            <td colspan="3">No data available in table</td>
+            <td colspan="4">No data available in table</td>
         </tr>
     @endforelse
     </tbody>

--- a/resources/views/widgets/latest-contact-logins.blade.php
+++ b/resources/views/widgets/latest-contact-logins.blade.php
@@ -1,0 +1,56 @@
+@php
+    use Amplify\System\Backend\Models\ContactLogin;
+
+    $contactLogins = ContactLogin::query()
+        ->with(['contact', 'customer', 'impersonator'])
+        ->latest()
+        ->limit(10)
+        ->get();
+@endphp
+
+<div class="card">
+    <div class="card-header d-flex justify-content-between align-items-center">
+        <span>Latest Contact Logins</span>
+        <a href="{{ backpack_url('contact-login') }}" class="btn btn-sm btn-link">See all</a>
+    </div>
+    <div class="card-body p-0">
+        <div class="table-responsive">
+            <table class="table table-striped table-hover mb-0">
+                <thead>
+                <tr>
+                    <th>Type</th>
+                    <th>Contact</th>
+                    <th>Customer</th>
+                    <th>Initiated By</th>
+                    <th>Last Logged In</th>
+                    <th>Last Logged Out</th>
+                    <th>Active</th>
+                </tr>
+                </thead>
+                <tbody>
+                @forelse($contactLogins as $entry)
+                    <tr>
+                        <td>{{ $entry->row_type === ContactLogin::ROW_TYPE_SESSION ? 'Session' : 'Assignment' }}</td>
+                        <td>{{ $entry->getContactDisplayLabel() }}</td>
+                        <td>{{ $entry->getCustomerDisplayLabel() }}</td>
+                        <td>{{ $entry->getImpersonatorDisplayName() }}</td>
+                        <td>{{ $entry->last_logged_in ? carbon_datetime($entry->last_logged_in) : '-' }}</td>
+                        <td>{{ $entry->last_logged_out ? carbon_datetime($entry->last_logged_out) : '-' }}</td>
+                        <td>
+                            @if($entry->active)
+                                <span class="badge bg-success">Yes</span>
+                            @else
+                                <span class="badge bg-secondary">No</span>
+                            @endif
+                        </td>
+                    </tr>
+                @empty
+                    <tr>
+                        <td colspan="7" class="text-center text-muted">No contact logins yet.</td>
+                    </tr>
+                @endforelse
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>

--- a/src/Http/Controllers/Admin/ContactCrudController.php
+++ b/src/Http/Controllers/Admin/ContactCrudController.php
@@ -15,6 +15,7 @@ use Amplify\System\Backend\Models\CustomerAddress;
 use Amplify\System\Backend\Models\CustomerPermission;
 use Amplify\System\Backend\Models\Event;
 use Amplify\System\Backend\Models\Role;
+use Amplify\System\Backend\Models\User;
 use Amplify\System\Factories\NotificationFactory;
 use Backpack\CRUD\app\Exceptions\BackpackProRequiredException;
 use Backpack\CRUD\app\Http\Controllers\Operations\CreateOperation;
@@ -1084,7 +1085,7 @@ class ContactCrudController extends BackpackCustomCrudController
         if (isset($inputs['id'])) {
             $currentContactModel = Contact::find($inputs['id']);
             if ($currentContactModel) {
-                $customerExcluded = $currentContactModel->contactLogins->pluck('customer_id')->toArray();
+                $customerExcluded = $currentContactModel->assignmentLogins->pluck('customer_id')->toArray();
             }
         }
 
@@ -1103,6 +1104,8 @@ class ContactCrudController extends BackpackCustomCrudController
             return redirect()->back()->with('message', 'This contact is disabled. Impersonating is not allowed.');
         }
 
+        $initiatedBy = Auth::guard(User::AUTH_GUARD)->user();
+
         Auth::guard(Contact::AUTH_GUARD)->logout();
 
         // Clear application cache
@@ -1115,7 +1118,7 @@ class ContactCrudController extends BackpackCustomCrudController
 
         $request->session()->put('impersonate', true);
 
-        event(new ContactLoggedIn($contact));
+        event(new ContactLoggedIn($contact, null, $initiatedBy));
 
         if (!empty($contact->redirect_route)) {
             return redirect()->intended($contact->redirect_route);

--- a/src/Http/Controllers/Admin/ContactLoginCrudController.php
+++ b/src/Http/Controllers/Admin/ContactLoginCrudController.php
@@ -35,7 +35,19 @@ class ContactLoginCrudController extends BackpackCustomCrudController
     {
         CRUD::setModel(ContactLogin::class);
         CRUD::setRoute(config('backpack.base.route_prefix').'/contact-login');
-        CRUD::setEntityNameStrings('contact-login', 'contact logins');
+        CRUD::setEntityNameStrings('contact login', 'contact logins');
+
+        if (! backpack_user()?->is_admin) {
+            CRUD::denyAccess(['create', 'update']);
+        }
+
+        $this->crud->query->with([
+            'contact',
+            'customer',
+            'warehouse',
+            'customerAddress',
+            'impersonator',
+        ]);
     }
 
     /**
@@ -50,6 +62,19 @@ class ContactLoginCrudController extends BackpackCustomCrudController
     protected function setupListOperation()
     {
         $this->crud->enableExportButtons();
+
+        CRUD::addFilter([
+            'name' => 'row_type',
+            'type' => 'dropdown',
+            'label' => 'Row Type',
+        ], function () {
+            return [
+                ContactLogin::ROW_TYPE_ASSIGNMENT => 'Assignment',
+                ContactLogin::ROW_TYPE_SESSION => 'Session',
+            ];
+        }, function ($value) {
+            $this->crud->addClause('where', 'row_type', $value);
+        });
 
         CRUD::addFilter([
             'name' => 'created_between',
@@ -69,40 +94,79 @@ class ContactLoginCrudController extends BackpackCustomCrudController
             $this->crud->addClause('where', 'created_at', '<=', $dates->to.' 23:59:59');
         });
 
+        CRUD::addFilter([
+            'name' => 'session_status',
+            'type' => 'dropdown',
+            'label' => 'Session Status',
+        ], function () {
+            return [
+                'open' => 'Open',
+                'closed' => 'Closed',
+            ];
+        }, function ($value) {
+            $this->crud->addClause('where', 'row_type', ContactLogin::ROW_TYPE_SESSION);
+
+            if ($value === 'open') {
+                $this->crud->addClause('whereNull', 'last_logged_out');
+            }
+
+            if ($value === 'closed') {
+                $this->crud->addClause('whereNotNull', 'last_logged_out');
+            }
+        });
+
         CRUD::addColumn([
-            'name' => 'contact_id',
-            'type' => 'relationship',
-            'entity' => 'contact',
-            'attribute' => 'name',
+            'name' => 'row_type',
+            'label' => 'Type',
+            'type' => 'enum',
+            'options' => [
+                ContactLogin::ROW_TYPE_ASSIGNMENT => 'Assignment',
+                ContactLogin::ROW_TYPE_SESSION => 'Session',
+            ],
         ]);
 
         CRUD::addColumn([
-            'name' => 'customer_id',
-            'type' => 'relationship',
-            'entity' => 'customer',
-            'attribute' => 'display_name',
+            'name' => 'contact_display',
+            'label' => 'Contact',
+            'type' => 'model_function',
+            'function_name' => 'getContactDisplayLabel',
+        ]);
+
+        CRUD::addColumn([
+            'name' => 'customer_display',
+            'label' => 'Customer',
+            'type' => 'model_function',
+            'function_name' => 'getCustomerDisplayLabel',
+        ]);
+
+        CRUD::addColumn([
+            'name' => 'impersonator_name',
+            'label' => 'Initiated By',
+            'type' => 'model_function',
+            'function_name' => 'getImpersonatorDisplayName',
         ]);
 
         CRUD::addColumn([
             'name' => 'warehouse_id',
-            'type' => 'relationship',
-            'entity' => 'warehouse',
-            'attribute' => 'name',
+            'label' => 'Warehouse',
+            'type' => 'model_function',
+            'function_name' => 'getWarehouseDisplayLabel',
         ]);
 
         CRUD::addColumn([
-            'name' => 'customer_address_id',
+            'name' => 'customer_address_display',
             'label' => 'Customer address',
-            'type' => 'relationship',
-            'entity' => 'customerAddress',
-            'attribute' => 'display_name',
+            'type' => 'model_function',
+            'function_name' => 'getCustomerAddressDisplayLabel',
         ]);
 
         CRUD::column('ship_to_name');
+
         CRUD::column('last_logged_in')->type('datetime');
         CRUD::column('last_logged_out')->type('datetime');
-        CRUD::column('created_at')->type('datetime');
-        CRUD::column('updated_at')->type('datetime');
+        CRUD::column('active')->type('boolean');
+
+        $this->addTimestampColumnsForSuperAdmin();
     }
 
     /**
@@ -114,6 +178,15 @@ class ContactLoginCrudController extends BackpackCustomCrudController
      */
     protected function setupCreateOperation()
     {
+        CRUD::addField([
+            'name' => 'row_type',
+            'type' => 'enum',
+            'options' => [
+                ContactLogin::ROW_TYPE_ASSIGNMENT => 'Assignment',
+                ContactLogin::ROW_TYPE_SESSION => 'Session',
+            ],
+            'default' => ContactLogin::ROW_TYPE_ASSIGNMENT,
+        ]);
         CRUD::addField([
             'name' => 'contact_id',
             'options' => (fn ($query) => $query->orderBy('name')->get()),
@@ -141,5 +214,90 @@ class ContactLoginCrudController extends BackpackCustomCrudController
     protected function setupUpdateOperation()
     {
         $this->setupCreateOperation();
+    }
+
+    /**
+     * Define what happens when the Show operation is loaded.
+     *
+     * @see https://backpackforlaravel.com/docs/crud-operation-show
+     *
+     * @return void
+     */
+    protected function setupShowOperation()
+    {
+        $this->crud->set('show.setFromDb', false);
+
+        CRUD::column('id');
+
+        CRUD::addColumn([
+            'name' => 'row_type',
+            'label' => 'Type',
+            'type' => 'enum',
+            'options' => [
+                ContactLogin::ROW_TYPE_ASSIGNMENT => 'Assignment',
+                ContactLogin::ROW_TYPE_SESSION => 'Session',
+            ],
+        ]);
+
+        CRUD::addColumn([
+            'name' => 'contact_display',
+            'label' => 'Contact',
+            'type' => 'model_function',
+            'function_name' => 'getContactDisplayLabel',
+            'limit' => 9999,
+        ]);
+
+        CRUD::addColumn([
+            'name' => 'customer_display',
+            'label' => 'Customer',
+            'type' => 'model_function',
+            'function_name' => 'getCustomerDisplayLabel',
+            'limit' => 9999,
+        ]);
+
+        CRUD::addColumn([
+            'name' => 'impersonator_name',
+            'label' => 'Initiated By',
+            'type' => 'model_function',
+            'function_name' => 'getImpersonatorDisplayName',
+            'limit' => 9999,
+        ]);
+
+        CRUD::addColumn([
+            'name' => 'warehouse_display',
+            'label' => 'Warehouse',
+            'type' => 'model_function',
+            'function_name' => 'getWarehouseDisplayLabel',
+            'limit' => 9999,
+        ]);
+
+        CRUD::addColumn([
+            'name' => 'customer_address_display',
+            'label' => 'Customer address',
+            'type' => 'model_function',
+            'function_name' => 'getCustomerAddressDisplayLabel',
+            'limit' => 9999,
+        ]);
+
+        CRUD::addColumn([
+            'name' => 'ship_to_name',
+            'limit' => 9999,
+        ]);
+
+        CRUD::column('last_logged_in')->type('datetime');
+        CRUD::column('last_logged_out')->type('datetime');
+        CRUD::column('active')->type('boolean');
+
+        $this->addTimestampColumnsForSuperAdmin();
+    }
+
+    protected function addTimestampColumnsForSuperAdmin(): void
+    {
+        if (! backpack_user()?->is_admin) {
+            return;
+        }
+
+        CRUD::column('created_at')->type('datetime');
+        CRUD::column('updated_at')->type('datetime');
     }
 }

--- a/src/Http/Controllers/Admin/ContactRegistrationCrudController.php
+++ b/src/Http/Controllers/Admin/ContactRegistrationCrudController.php
@@ -506,7 +506,7 @@ class ContactRegistrationCrudController extends BackpackCustomCrudController
             $roles = [];
             $permissions = [];
             $contact = $this->crud->entry;
-            $contact->contactLogins()
+            $contact->assignmentLogins()
                 ->where('customer_id', '<>', $contact->customer_id)
                 ->delete();
 
@@ -516,7 +516,7 @@ class ContactRegistrationCrudController extends BackpackCustomCrudController
 
             foreach ($request->contactLogins ?? [] as $login_customer) {
 
-                ContactLogin::firstOrCreate([
+                ContactLogin::findOrCreateAssignment([
                     'contact_id' => $contact->id,
                     'customer_id' => $login_customer['customer_id'],
                     'warehouse_id' => $login_customer['warehouse_id'],

--- a/src/Models/Contact.php
+++ b/src/Models/Contact.php
@@ -80,10 +80,7 @@ class Contact extends Authenticatable implements Auditable, MessageableInterface
                 Storage::disk('uploads')->delete($model->profile_image);
             }
 
-            ContactLogin::where([
-                'contact_id' => $model->id,
-                'customer_id' => $model->customer_id,
-            ])->delete();
+            ContactLogin::where('contact_id', $model->id)->delete();
         });
 
         static::saving(function ($model) {
@@ -262,6 +259,16 @@ class Contact extends Authenticatable implements Auditable, MessageableInterface
         return $this->hasMany(ContactLogin::class);
     }
 
+    public function assignmentLogins()
+    {
+        return $this->hasMany(ContactLogin::class)->assignment();
+    }
+
+    public function sessionLogins()
+    {
+        return $this->hasMany(ContactLogin::class)->session()->orderByDesc('last_logged_in');
+    }
+
     /**
      * same contact login
      *
@@ -269,7 +276,7 @@ class Contact extends Authenticatable implements Auditable, MessageableInterface
      */
     public function backendContactLogins()
     {
-        return $this->contactLogins()->where('customer_id', '!=', $this->customer_id);
+        return $this->assignmentLogins()->where('customer_id', '!=', $this->customer_id);
     }
 
     public function activeCustomer(): BelongsTo
@@ -368,10 +375,9 @@ class Contact extends Authenticatable implements Auditable, MessageableInterface
 
     public function updateContactLoginAsPerEntry()
     {
-        ContactLogin::updateOrCreate([
+        ContactLogin::findOrCreateAssignment([
             'contact_id' => $this->id,
             'customer_id' => $this->customer_id,
-        ], [
             'warehouse_id' => $this->warehouse_id,
             'customer_address_id' => $this->customer_address_id,
             'ship_to_name' => $this->customer_address?->address_name ?? null,
@@ -381,7 +387,7 @@ class Contact extends Authenticatable implements Auditable, MessageableInterface
     public function validateActiveCustomer()
     {
         if ($this->active_customer_id) {
-            $doesntExist = $this->contactLogins()->where('customer_id', $this->active_customer_id)->doesntExist();
+            $doesntExist = $this->assignmentLogins()->where('customer_id', $this->active_customer_id)->doesntExist();
 
             if ($doesntExist) {
                 $this->update(['active_customer_id' => null]);

--- a/src/Models/ContactLogin.php
+++ b/src/Models/ContactLogin.php
@@ -6,25 +6,21 @@ use Backpack\CRUD\app\Models\Traits\CrudTrait;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Database\Eloquent\Model as EloquentModel;
+use Illuminate\Support\Collection;
 
 class ContactLogin extends Model
 {
     use CrudTrait;
 
-    /*
-    |--------------------------------------------------------------------------
-    | GLOBAL VARIABLES
-    |--------------------------------------------------------------------------
-    */
+    public const ROW_TYPE_ASSIGNMENT = 'assignment';
+
+    public const ROW_TYPE_SESSION = 'session';
 
     protected $table = 'contact_logins';
 
-    // protected $primaryKey = 'id';
-    // public $timestamps = false;
     protected $guarded = ['id'];
-    // protected $fillable = [];
-    // protected $hidden = [];
-    // protected $dates = [];
 
     protected $casts = [
         'active' => 'boolean',
@@ -53,6 +49,185 @@ class ContactLogin extends Model
         })->paginate($filters['per_page'] ?? getPaginationLengths()[0]);
     }
 
+    public static function resolveCustomerId(Contact $contact): int
+    {
+        if (config('amplify.basic.enable_multi_customer_manage', false) && $contact->active_customer_id != null) {
+            return (int) $contact->active_customer_id;
+        }
+
+        return (int) $contact->customer_id;
+    }
+
+    public static function startSession(Contact $contact, ?EloquentModel $initiatedBy = null): self
+    {
+        $customerId = self::resolveCustomerId($contact);
+
+        // Auth::login() regenerates the session id, so close the prior row by contact_login_id
+        // (still in session data) rather than matching session_id on the old row.
+        self::endSession();
+
+        $login = self::create([
+            'row_type' => self::ROW_TYPE_SESSION,
+            'contact_id' => $contact->id,
+            'customer_id' => $customerId,
+            'impersonate_type' => $initiatedBy?->getMorphClass(),
+            'impersonate_id' => $initiatedBy?->getKey(),
+            'last_logged_in' => now(),
+            'active' => true,
+        ]);
+
+        session(['contact_login_id' => $login->id]);
+
+        return $login;
+    }
+
+    public static function endSession(?int $sessionRowId = null): void
+    {
+        $id = $sessionRowId ?? session('contact_login_id');
+
+        if (! $id) {
+            return;
+        }
+
+        self::query()
+            ->session()
+            ->where('id', $id)
+            ->whereNull('last_logged_out')
+            ->update([
+                'last_logged_out' => now(),
+                'active' => false,
+            ]);
+
+        session()->forget('contact_login_id');
+    }
+
+    /**
+     * Open session rows for a contact, optionally excluding the current session row.
+     */
+    public static function openSessionsForContact(int $contactId, ?int $exceptRowId = null): Collection
+    {
+        return self::query()
+            ->session()
+            ->where('contact_id', $contactId)
+            ->whereNull('last_logged_out')
+            ->when($exceptRowId, fn (Builder $query) => $query->where('id', '!=', $exceptRowId))
+            ->orderByDesc('last_logged_in')
+            ->get();
+    }
+
+    /**
+     * Whether this contact has active sessions in other browsers/devices.
+     */
+    public static function hasOtherActiveSessions(int $contactId): bool
+    {
+        $currentRowId = session('contact_login_id');
+
+        return self::openSessionsForContact($contactId, is_numeric($currentRowId) ? (int) $currentRowId : null)->isNotEmpty();
+    }
+
+    public static function findOrCreateAssignment(array $attributes): self
+    {
+        return self::query()->updateOrCreate(
+            [
+                'contact_id' => $attributes['contact_id'],
+                'customer_id' => $attributes['customer_id'],
+                'row_type' => self::ROW_TYPE_ASSIGNMENT,
+            ],
+            array_merge($attributes, ['row_type' => self::ROW_TYPE_ASSIGNMENT])
+        );
+    }
+
+    public static function currentSessionRow(): ?self
+    {
+        $sessionRowId = session('contact_login_id');
+
+        if ($sessionRowId) {
+            return self::query()->session()->find($sessionRowId);
+        }
+
+        return null;
+    }
+
+    public static function formatNameWithEmail(?string $name, ?string $email): string
+    {
+        $name = trim((string) $name);
+        $email = trim((string) $email);
+
+        if ($name !== '' && $email !== '') {
+            return "{$name} ({$email})";
+        }
+
+        if ($name !== '') {
+            return $name;
+        }
+
+        if ($email !== '') {
+            return $email;
+        }
+
+        return 'N/A';
+    }
+
+    public function getContactDisplayLabel(): string
+    {
+        $contact = $this->contact;
+
+        if (! $contact) {
+            return 'N/A';
+        }
+
+        return self::formatNameWithEmail($contact->name, $contact->email);
+    }
+
+    public function getCustomerDisplayLabel(): string
+    {
+        $customer = $this->customer;
+
+        if (! $customer) {
+            return 'N/A';
+        }
+
+        return self::formatNameWithEmail($customer->display_name, $customer->email ?? null);
+    }
+
+    public function getWarehouseDisplayLabel(): string
+    {
+        $warehouse = $this->warehouse;
+
+        if (! $warehouse) {
+            return '-';
+        }
+
+        $code = trim((string) ($warehouse->code ?? ''));
+        $name = trim((string) ($warehouse->name ?? ''));
+
+        if ($code !== '' && $name !== '') {
+            return "{$code} - {$name}";
+        }
+
+        return $name ?: $code ?: '-';
+    }
+
+    public function getCustomerAddressDisplayLabel(): string
+    {
+        return $this->customerAddress?->display_name ?? '-';
+    }
+
+    public function getImpersonatorDisplayName(): string
+    {
+        if (! $this->impersonate_type) {
+            return 'Self';
+        }
+
+        $impersonator = $this->impersonator;
+
+        if (! $impersonator) {
+            return class_basename($this->impersonate_type).' #'.$this->impersonate_id;
+        }
+
+        return self::formatNameWithEmail($impersonator->name ?? null, $impersonator->email ?? null);
+    }
+
     /*
     |--------------------------------------------------------------------------
     | RELATIONS
@@ -76,6 +251,11 @@ class ContactLogin extends Model
     public function customerAddress(): BelongsTo
     {
         return $this->belongsTo(CustomerAddress::class);
+    }
+
+    public function impersonator(): MorphTo
+    {
+        return $this->morphTo(__FUNCTION__, 'impersonate_type', 'impersonate_id');
     }
 
     public function getRolesAttribute()
@@ -111,16 +291,18 @@ class ContactLogin extends Model
     | SCOPES
     |--------------------------------------------------------------------------
     */
+    public function scopeAssignment(Builder $query): Builder
+    {
+        return $query->where('row_type', self::ROW_TYPE_ASSIGNMENT);
+    }
 
-    /*
-    |--------------------------------------------------------------------------
-    | ACCESSORS
-    |--------------------------------------------------------------------------
-    */
+    public function scopeSession(Builder $query): Builder
+    {
+        return $query->where('row_type', self::ROW_TYPE_SESSION);
+    }
 
-    /*
-    |--------------------------------------------------------------------------
-    | MUTATORS
-    |--------------------------------------------------------------------------
-    */
+    public function scopeOpen(Builder $query): Builder
+    {
+        return $query->whereNull('last_logged_out');
+    }
 }


### PR DESCRIPTION
## Summary

Introduces **assignment vs session** rows on `contact_logins` so multi-customer config stays separate from login/impersonation audit history. Updates admin CRUD and adds a dashboard widget for recent activity.

## What changed

### Database
- New migration adds:
  - `row_type` — `assignment` (config) or `session` (login audit)
  - `impersonate_type` / `impersonate_id` — who started the session (admin, contact, or self)
- Existing rows are migrated to `assignment`

### Models
- **ContactLogin**
  - Scopes: `assignment()`, `session()`
  - `startSession()` / `endSession()` — create and close session rows via `session('contact_login_id')`
  - Display helpers for admin UI (contact, customer, warehouse, address, impersonator)
  - `findOrCreateAssignment()` for assignment rows
- **Contact**
  - `assignmentLogins()` / `sessionLogins()` relationships
  - Hard delete removes all related `contact_logins` rows

### Admin
- **ContactLoginCrudController**
  - Lists both assignment and session rows
  - Filters: row type, session status (open/closed), date range
  - Readable columns via model display helpers
  - Show/preview operation added
  - Create/edit restricted to admins
- **ContactCrudController** — admin impersonate passes initiator for audit
- **ContactRegistrationCrudController** — creates assignment rows only
- **contact-login-history** partial — uses session rows with initiator column

### Dashboard widget
- New view: `resources/views/widgets/latest-contact-logins.blade.php`
- Shows latest 10 contact login rows (type, contact, customer, initiated by, logged in/out, active)
- “See all” links to Contact Login admin page

## Deploy notes
- Run migration: `php artisan migrate`

## Related (main app)
- Register widget in `resources/views/vendor/backpack/base/dashboard.blade.php` (requires `contact-login.list` permission)

## Client repo setup (dashboard widget)

The widget view ships in this package. To show it on the admin dashboard, add the following to the client repo’s `resources/views/vendor/backpack/base/dashboard.blade.php` inside the `@php` block (same pattern as other dashboard widgets):

```php
if (backpack_user()->can('contact-login.list')) {
    $widgets['before_content'][] = [
        'type' => 'div',
        'class' => 'row',
        'content' => [
            [
                'type' => 'view',
                'view' => 'backend::widgets.latest-contact-logins',
                'wrapperClass' => 'col-12',
            ],
        ],
    ];
}