### PR TITLE
fix(admin): show order notes and product code in orders preview

### DIFF
--- a/src/Http/Controllers/Admin/DraftOrderCrudController.php
+++ b/src/Http/Controllers/Admin/DraftOrderCrudController.php
@@ -494,6 +494,11 @@ class DraftOrderCrudController extends BackpackCustomCrudController
                 'type' => 'table-related',
                 'columns' => [
                     [
+                        'name' => 'product_code',
+                        'label' => 'Product Code',
+                        'type' => 'text',
+                    ],
+                    [
                         'name' => 'product_name',
                         'label' => 'Name',
                         'type' => 'text',

--- a/src/Http/Controllers/Admin/DraftOrderCrudController.php
+++ b/src/Http/Controllers/Admin/DraftOrderCrudController.php
@@ -548,9 +548,27 @@ class DraftOrderCrudController extends BackpackCustomCrudController
                 'decimals' => 2,
             ],
             [
-                'name' => 'notes',
-                'type' => 'textarea',
-                'label' => 'Notes',
+                'name' => 'orderNotes',
+                'label' => 'Order Notes',
+                'type' => 'table-related',
+                'columns' => [
+                    [
+                        'name' => 'subject',
+                        'label' => 'Subject',
+                        'type' => 'text',
+                    ],
+                    [
+                        'name' => 'formatted_date',
+                        'label' => 'Date',
+                        'type' => 'model_function',
+                        'function_name' => 'getFormattedDateValue',
+                    ],
+                    [
+                        'name' => 'note',
+                        'label' => 'Note',
+                        'type' => 'text',
+                    ],
+                ],
             ],
             [
                 'name' => 'draft_name',

--- a/src/Http/Controllers/Admin/OrderCrudController.php
+++ b/src/Http/Controllers/Admin/OrderCrudController.php
@@ -597,6 +597,11 @@ class OrderCrudController extends BackpackCustomCrudController
                 'type' => 'table-related',
                 'columns' => [
                     [
+                        'name' => 'product_code',
+                        'label' => 'Product Code',
+                        'type' => 'text',
+                    ],
+                    [
                         'name' => 'local_product_name',
                         'label' => 'Name',
                         'type' => 'text',

--- a/src/Http/Controllers/Admin/OrderCrudController.php
+++ b/src/Http/Controllers/Admin/OrderCrudController.php
@@ -665,9 +665,27 @@ class OrderCrudController extends BackpackCustomCrudController
                 'decimals' => 2,
             ],
             [
-                'name' => 'notes',
-                'type' => 'textarea',
-                'label' => 'Notes',
+                'name' => 'orderNotes',
+                'label' => 'Order Notes',
+                'type' => 'table-related',
+                'columns' => [
+                    [
+                        'name' => 'subject',
+                        'label' => 'Subject',
+                        'type' => 'text',
+                    ],
+                    [
+                        'name' => 'formatted_date',
+                        'label' => 'Date',
+                        'type' => 'model_function',
+                        'function_name' => 'getFormattedDateValue',
+                    ],
+                    [
+                        'name' => 'note',
+                        'label' => 'Note',
+                        'type' => 'text',
+                    ],
+                ],
             ],
             [
                 'name' => 'draft_name',

--- a/src/Http/Controllers/Admin/QuoteCrudController.php
+++ b/src/Http/Controllers/Admin/QuoteCrudController.php
@@ -312,9 +312,27 @@ class QuoteCrudController extends BackpackCustomCrudController
                 'decimals' => 2,
             ],
             [
-                'name' => 'notes',
-                'type' => 'textarea',
-                'label' => 'Notes',
+                'name' => 'orderNotes',
+                'label' => 'Order Notes',
+                'type' => 'table-related',
+                'columns' => [
+                    [
+                        'name' => 'subject',
+                        'label' => 'Subject',
+                        'type' => 'text',
+                    ],
+                    [
+                        'name' => 'formatted_date',
+                        'label' => 'Date',
+                        'type' => 'model_function',
+                        'function_name' => 'getFormattedDateValue',
+                    ],
+                    [
+                        'name' => 'note',
+                        'label' => 'Note',
+                        'type' => 'text',
+                    ],
+                ],
             ],
             [
                 'name' => 'draft_name',

--- a/src/Http/Controllers/Admin/QuoteCrudController.php
+++ b/src/Http/Controllers/Admin/QuoteCrudController.php
@@ -246,6 +246,11 @@ class QuoteCrudController extends BackpackCustomCrudController
                 'type' => 'table-related',
                 'columns' => [
                     [
+                        'name' => 'product_code',
+                        'label' => 'Product Code',
+                        'type' => 'text',
+                    ],
+                    [
                         'name' => 'product_name',
                         'label' => 'Name',
                         'type' => 'text',

--- a/src/Models/CustomerOrderNote.php
+++ b/src/Models/CustomerOrderNote.php
@@ -27,4 +27,9 @@ class CustomerOrderNote extends Model
     {
         return $this->belongsTo(CustomerOrder::class);
     }
+
+    public function getFormattedDateValue()
+    {
+        return carbon_datetime($this->created_at ?? $this->date);
+    }
 }

--- a/src/Seeders/EventSeeder.php
+++ b/src/Seeders/EventSeeder.php
@@ -227,6 +227,8 @@ HTML,
     </tr>
 </table>
 
+__order_details__
+
 <p style="margin: 25px 0;">You can view complete order details by clicking the button below:</p>
 
 <p>__admin_order_details_url__</p>
@@ -274,6 +276,8 @@ HTML,
     </tr>
 </table>
 
+__order_details__
+
 <p style="margin: 25px 0;">You can view complete order details by clicking the button below:</p>
 
 <p>__customer_order_details_url__</p>
@@ -287,7 +291,7 @@ __company_name__</p>
 HTML,
                         'show_button' => true,
                         'button_text' => 'View Order Details',
-                        'button_url' => '/orders/:id',
+                        'button_url' => '__customer_order_details_url__',
                         'notification_type' => 'emailable',
                         'enabled' => true,
                     ],
@@ -505,7 +509,7 @@ __company_name__ System Notification</p>
 HTML,
                         'show_button' => true,
                         'button_text' => 'Synchronization List',
-                        'button_url' => route_uri('product-sync.index'),
+                        'button_url' => route_uri('synchronization.index'),
                         'notification_type' => 'emailable',
                         'enabled' => true,
                     ],

--- a/src/Seeders/EventSeeder.php
+++ b/src/Seeders/EventSeeder.php
@@ -159,7 +159,7 @@ HTML,
                     ['name' => '__notes__', 'description' => 'Order Notes'],
                     ['name' => '__customer_order_details_url__', 'description' => '/customer-profile-order-list-items?order_id=:id'],
                     ['name' => '__customer_quotation_details_url__', 'description' => '/customer-profile-quotation-list-items?order_id=:id'],
-                    ['name' => '__admin_order_details_url__', 'description' => '/admin/order-line?order_line_id=:id'],
+                    ['name' => '__admin_order_details_url__', 'description' => '/admin/order/:id/show'],
 
                     ['name' => '__erp_order_number__', 'description' => 'ERP Order Number'],
                     ['name' => '__contact_email__', 'description' => 'Email of the contact'],
@@ -229,7 +229,7 @@ HTML,
 
 <p style="margin: 25px 0;">You can view complete order details by clicking the button below:</p>
 
-<p>__customer_order_details_url__</p>
+<p>__admin_order_details_url__</p>
 
 <p>If you have any questions or require assistance, please contact the administrator.</p>
 
@@ -240,7 +240,7 @@ __company_name__</p>
 HTML,
                         'show_button' => true,
                         'button_text' => 'View Order Details',
-                        'button_url' => '/orders/:id',
+                        'button_url' => '__admin_order_details_url__',
                         'notification_type' => 'emailable',
                         'enabled' => true,
                     ],
@@ -307,7 +307,7 @@ HTML,
                     ['name' => '__notes__', 'description' => 'Order Notes'],
                     ['name' => '__customer_order_details_url__', 'description' => '/customer-profile-order-list-items?order_id=:id'],
                     ['name' => '__customer_quotation_details_url__', 'description' => '/customer-profile-quotation-list-items?order_id=:id'],
-                    ['name' => '__admin_order_details_url__', 'description' => '/admin/order-line?order_line_id=:id'],
+                    ['name' => '__admin_order_details_url__', 'description' => '/admin/order/:id/show'],
                 ],
                 'eventRecipents' => [
                     ['name' => 'Admin', 'event_action_field' => 'is_get_admin', 'description' => 'System Admcontactinistrator'],
@@ -332,7 +332,7 @@ HTML,
                     ['name' => '__notes__', 'description' => 'Order Notes'],
                     ['name' => '__customer_order_details_url__', 'description' => '/customer-profile-order-list-items?order_id=:id'],
                     ['name' => '__customer_quotation_details_url__', 'description' => '/customer-profile-quotation-list-items?order_id=:id'],
-                    ['name' => '__admin_order_details_url__', 'description' => '/admin/order-line?order_line_id=:id'],
+                    ['name' => '__admin_order_details_url__', 'description' => '/admin/order/:id/show'],
                 ],
                 'eventRecipents' => [
                     ['name' => 'Admin', 'event_action_field' => 'is_get_admin', 'description' => 'System Administrator'],
@@ -356,7 +356,7 @@ HTML,
                     ['name' => '__notes__', 'description' => 'Order Notes'],
                     ['name' => '__customer_order_details_url__', 'description' => '/customer-profile-order-list-items?order_id=:id'],
                     ['name' => '__customer_quotation_details_url__', 'description' => '/customer-profile-quotation-list-items?order_id=:id'],
-                    ['name' => '__admin_order_details_url__', 'description' => '/admin/order-line?order_line_id=:id'],
+                    ['name' => '__admin_order_details_url__', 'description' => '/admin/order/:id/show'],
                 ],
                 'eventRecipents' => [
                     ['name' => 'Admin', 'event_action_field' => 'is_get_admin', 'description' => 'System Administrator'],


### PR DESCRIPTION
## Summary

Fixes admin order preview issues reported by Allred's: order notes were not visible, and product code was missing from order lines. Also updates default event seeder templates and fixes a broken seeder route.

## Changes

- **Admin → Orders → Preview**
  - Show order notes from `customer_order_notes` via the `orderNotes` relationship
  - Add **Product Code** as the first column in the Order Lines table
  - Remove the unused legacy **Notes** field (`customer_orders.notes`) to avoid confusion
- **Draft Orders / Quotes preview**
  - Show order notes from `orderNotes` (same fix as orders preview)
  - Legacy **Notes** field removed from preview
- **`CustomerOrderNote`**
  - Add `getFormattedDateValue()` using `carbon_datetime()` so dates match **Created At** format (e.g. `05 Jul 2026, 11:02`)
- **`EventSeeder`**
  - Add `__order_details__` to default Order Received email templates (admin + customer)
  - Use `__admin_order_details_url__` / `__customer_order_details_url__` for button URLs
  - Fix seeder error: replace missing `product-sync.index` route with `synchronization.index`

## Files changed

- `src/Http/Controllers/Admin/OrderCrudController.php`
- `src/Http/Controllers/Admin/DraftOrderCrudController.php`
- `src/Http/Controllers/Admin/QuoteCrudController.php`
- `src/Models/CustomerOrderNote.php`
- `src/Seeders/EventSeeder.php`

## Test plan

- [ ] Open **Admin → Orders → Preview** for an order with notes → verify **Order Notes** shows subject, date, and note
- [ ] Verify **Product Code** is the first column in order lines (e.g. web order `#0001045`)
- [ ] Confirm there is no empty legacy **Notes** field
- [ ] Run `php artisan db:seed --class=Amplify\System\Backend\Seeders\EventSeeder` on dev only — note this **truncates** events/templates and **deletes all `event_actions`**

## Manual follow-up

Seeder changes do not update existing DB email templates. In **Admin → Events → Order Received**, add `__order_details__` to admin and customer templates if not already present.