### PR TITLE
Fix product image updates, CODE_VARIANT naming, and --rescan option handling

### DIFF
--- a/config/pim.php
+++ b/config/pim.php
@@ -52,6 +52,9 @@ return [
         // queue / chunk settings
         'scan_file_chunk' => (int) env('AMPLIFY_PRODUCT_IMAGE_SCAN_FILE_CHUNK', 2000),
         'code_chunk' => (int) env('AMPLIFY_PRODUCT_IMAGE_CODE_CHUNK', 500),
+        // logging
+        'log_channel' => env('AMPLIFY_PRODUCT_IMAGE_LOG_CHANNEL', null), // null => default laravel.log
+        'cleanup_existing' => (bool) env('AMPLIFY_PRODUCT_IMAGE_CLEANUP_EXISTING', true),
     ],
     'synchronization' => [
         'attributes' => [

--- a/src/Commands/UpdateProductImageFromStorage.php
+++ b/src/Commands/UpdateProductImageFromStorage.php
@@ -2,7 +2,6 @@
 
 namespace Amplify\System\Backend\Commands;
 
-
 use Amplify\System\Backend\Jobs\ProductImage\DispatchProcessCodesFromTableJob;
 use Amplify\System\Backend\Jobs\ProductImage\ScanScanningFolderToTableJob;
 use Illuminate\Console\Command;
@@ -10,13 +9,13 @@ use Illuminate\Support\Facades\Bus;
 
 class UpdateProductImageFromStorage extends Command
 {
-    protected $signature = 'update:product-images {--rescan : Rescan staging folder and rebuild product_image_files table}';
+    protected $signature = 'update:product-images {--rescan=1 : Rescan staging folder and rebuild product_image_files table}';
 
     protected $description = 'Sync product images from staging folder (file-based only)';
 
     public function handle(): int
     {
-        $rescan = (bool) $this->option('rescan');
+        $rescan = $this->wantsRescan();
 
         Bus::chain([
             new ScanScanningFolderToTableJob($rescan),
@@ -30,5 +29,19 @@ class UpdateProductImageFromStorage extends Command
         );
 
         return self::SUCCESS;
+    }
+
+    private function wantsRescan(): bool
+    {
+        // Signature default is "1" when omitted.
+        // Bare `--rescan` (optional value) yields null → treat as enabled.
+        // Scheduler / schedule:list form `--rescan=1` / `--rescan='1'` is accepted.
+        $value = $this->option('rescan');
+
+        if ($value === null) {
+            return true;
+        }
+
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
     }
 }

--- a/src/Jobs/ProductImage/ScanScanningFolderToTableJob.php
+++ b/src/Jobs/ProductImage/ScanScanningFolderToTableJob.php
@@ -8,7 +8,6 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 
@@ -63,9 +62,28 @@ class ScanScanningFolderToTableJob implements ShouldQueue
         $seen = 0;
         $changed = 0;
         $skipped = 0;
+        $deletedDotFiles = 0;
 
         foreach ($allFiles as $path) {
             $basename = basename($path);
+
+            // Delete macOS metadata files immediately
+            if (str_starts_with($basename, '._')) {
+                try {
+                    $disk->delete($path);
+                    $deletedDotFiles++;
+                } catch (\Throwable $e) {
+                    Log::warning('Failed to delete dot-underscore file', [
+                        'disk' => $diskName,
+                        'path' => $path,
+                        'error' => $e->getMessage(),
+                    ]);
+                }
+
+                $skipped++;
+
+                continue;
+            }
 
             if ($this->shouldSkipFile($basename)) {
                 $skipped++;
@@ -117,6 +135,7 @@ class ScanScanningFolderToTableJob implements ShouldQueue
             'files_seen' => $seen,
             'files_skipped' => $skipped,
             'rows_changed_or_added' => $changed,
+            'deleted_dot_files' => $deletedDotFiles,
         ]);
     }
 
@@ -223,12 +242,26 @@ class ScanScanningFolderToTableJob implements ShouldQueue
     /**
      * Returns: [code, kind, variant]
      *
-     * Supported:
-     * main:       76-038
-     * additional: ._76-038
-     * additional: ._76-038_A
-     * additional: ._76-038_B
-     * additional: ._76-038_C
+     * Supported filename formats:
+     *
+     * Main image:
+     *   PRODUCTCODE
+     *   e.g.
+     *     76-038
+     *
+     * Additional images:
+     *   PRODUCTCODE_VARIANT
+     *   e.g.
+     *     76-038_A
+     *     76-038_B
+     *     76-038_C
+     *     76-038_01
+     *     76-038_FRONT
+     *
+     * Notes:
+     * - Files prefixed with "._" are macOS metadata (AppleDouble) files.
+     * - These files are deleted during the scanning scan and are never processed.
+     * - Additional images are identified only by the "_VARIANT" suffix.
      */
     private function parseCodeKindAndVariant(string $nameNoExt): array
     {
@@ -238,7 +271,8 @@ class ScanScanningFolderToTableJob implements ShouldQueue
             return ['', 'main', ''];
         }
 
-        if (preg_match('/^\._(.+)_([A-Z0-9]+)$/i', $nameNoExt, $matches)) {
+        // PRODUCTCODE_A
+        if (preg_match('/^(.+)_([A-Z0-9]+)$/i', $nameNoExt, $matches)) {
             $code = trim($matches[1]);
             $variant = strtoupper($matches[2]);
 
@@ -247,14 +281,7 @@ class ScanScanningFolderToTableJob implements ShouldQueue
             }
         }
 
-        if (preg_match('/^\._(.+)$/', $nameNoExt, $matches)) {
-            $code = trim($matches[1]);
-
-            if ($code !== '') {
-                return [$code, 'additional', ''];
-            }
-        }
-
+        // PRODUCTCODE
         return [$nameNoExt, 'main', ''];
     }
 }

--- a/src/Services/ProductImageProcessor.php
+++ b/src/Services/ProductImageProcessor.php
@@ -159,9 +159,13 @@ class ProductImageProcessor
             return null;
         }
 
-        $dest = $variant === ''
-            ? "{$this->outputBase}/._{$code}.jpg"
-            : "{$this->outputBase}/._{$code}_{$variant}.jpg";
+        if ($variant === '') {
+            Log::warning('Additional missing variant', compact('code', 'src'));
+
+            return null;
+        }
+
+        $dest = "{$this->outputBase}/{$code}_{$variant}.jpg";
 
         if (! $this->disk->move($src, $dest)) {
             Log::warning('Additional move failed', compact('code', 'src', 'dest'));
@@ -275,7 +279,7 @@ class ProductImageProcessor
 
         $name = pathinfo($path, PATHINFO_FILENAME);
 
-        if (preg_match('/^\._'.preg_quote($code, '/').'_([A-Z0-9]+)$/i', $name, $m)) {
+        if (preg_match('/^'.preg_quote($code, '/').'_([A-Z0-9]+)$/i', $name, $m)) {
             return strtoupper($m[1]);
         }
 

--- a/src/Services/ProductImageProcessor.php
+++ b/src/Services/ProductImageProcessor.php
@@ -125,8 +125,11 @@ class ProductImageProcessor
 
     private function processAdditional(string $code, array $list, $existingJson): ?string
     {
+        // ProductImage casts `additional` to array, so existing values may already be arrays.
+        $existingEncoded = $this->encodeAdditional($existingJson);
+
         if (empty($list)) {
-            return $existingJson;
+            return $existingEncoded;
         }
 
         $newUrls = [];
@@ -140,12 +143,11 @@ class ProductImageProcessor
         }
 
         if (empty($newUrls)) {
-            return $existingJson;
+            return $existingEncoded;
         }
 
-        return json_encode(
-            $this->mergeUrls($this->decode($existingJson), $newUrls),
-            JSON_UNESCAPED_SLASHES
+        return $this->encodeAdditional(
+            $this->mergeUrls($this->decode($existingJson), $newUrls)
         );
     }
 
@@ -236,7 +238,28 @@ class ProductImageProcessor
 
     private function decode($json): array
     {
+        if (is_array($json)) {
+            return $json;
+        }
+
         return is_string($json) ? (json_decode($json, true) ?: []) : [];
+    }
+
+    private function encodeAdditional($value): ?string
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if (is_array($value)) {
+            return empty($value) ? null : json_encode(array_values($value), JSON_UNESCAPED_SLASHES);
+        }
+
+        if (is_string($value)) {
+            return $value;
+        }
+
+        return null;
     }
 
     private function mergeUrls(array $old, array $new): array


### PR DESCRIPTION
## Summary
- Fixes `TypeError` in `ProductImageProcessor::processAdditional()` when running `php artisan update:product-images` for products that already have additional images in the DB (e.g. `160020.122.WH3`).
- Root cause: `ProductImage.additional` is cast to an `array`, but `processAdditional()` returned that value directly while declaring a `?string` return type.
- Normalizes existing `additional` values (array or JSON string) so existing URLs are preserved and merged correctly.
- Updates staging scan to delete macOS `._*` metadata files instead of treating them as additional images.
- Switches additional-image naming from `._CODE` / `._CODE_A` to `CODE_VARIANT` (e.g. `160020.122.WH3_A.jpg`).
- Aligns `ProductImageProcessor` output paths and variant parsing with the new naming convention.
- Updates `update:product-images` so `--rescan` accepts a value (`--rescan=1` / `--rescan='1'`), matching scheduler/`schedule:list` output; default is `1` (full rebuild). Use `--rescan=0` for incremental.

## Image naming convention
Drop files into the scanning folder using these names:
| Filename | Code | Kind | Variant |
|----------|------|------|---------|
| `76-038.jpg` | `76-038` | main | `''` |
| `76-038_A.jpg` | `76-038` | additional | `A` |
| `76-038_B.jpg` | `76-038` | additional | `B` |
| `76-038_C.webp` | `76-038` | additional | `C` |
| `76-038_01.jpg` | `76-038` | additional | `01` |
| `76-038_FRONT.jpg` | `76-038` | additional | `FRONT` |

Notes:
- Main image = exact product code (no `_VARIANT` suffix).
- Additional image = `PRODUCTCODE_VARIANT` (variant must be alphanumeric).
- Files prefixed with `._` are treated as macOS metadata and are **deleted**, not processed.

