### PR TITLE
fix: forward ship-to address lines for any address_name in ERP order creation

### DIFF
--- a/src/Models/CustomerOrder.php
+++ b/src/Models/CustomerOrder.php
@@ -244,16 +244,16 @@ class CustomerOrder extends Model implements Auditable
                 'request' => request()->all(),
             ];
 
+            // Forward selected/custom ship-to address lines for any ship-to (MAIN, SAME, TEMP, etc.)
             if (isset($data['address_name'])) {
-
-                $order_infos['ship_to_address1'] = $data['address_name'] != 'TEMP' ? '' : ($data['address_1'] ?? '');
-                $order_infos['ship_to_address2'] = $data['address_name'] != 'TEMP' ? '' : ($data['address_2'] ?? '');
-                $order_infos['ship_to_address3'] = $data['address_name'] != 'TEMP' ? '' : ($data['address_3'] ?? '');
-                $order_infos['ship_to_city'] = $data['address_name'] != 'TEMP' ? '' : ($data['address_city'] ?? '');
-                $order_infos['ship_to_country_code'] = $data['address_name'] != 'TEMP' ? '' : ($data['address_country_code'] ?? '');
-                $order_infos['ship_to_state'] = $data['address_name'] != 'TEMP' ? '' : ($data['address_state'] ?? '');
-                $order_infos['ship_to_zip_code'] = $data['address_name'] != 'TEMP' ? '' : ($data['address_zip_code'] ?? '');
-                $order_infos['ship_to_phone'] = $data['address_name'] != 'TEMP' ? '' : ($data['shipping_phone'] ?? '');
+                $order_infos['ship_to_address1'] = $data['address_1'] ?? '';
+                $order_infos['ship_to_address2'] = $data['address_2'] ?? '';
+                $order_infos['ship_to_address3'] = $data['address_3'] ?? '';
+                $order_infos['ship_to_city'] = $data['address_city'] ?? '';
+                $order_infos['ship_to_country_code'] = $data['address_country_code'] ?? '';
+                $order_infos['ship_to_state'] = $data['address_state'] ?? '';
+                $order_infos['ship_to_zip_code'] = $data['address_zip_code'] ?? '';
+                $order_infos['ship_to_phone'] = $data['shipping_phone'] ?? $data['phone'] ?? '';
             }
 
             if (isset($data['order_type'])) {


### PR DESCRIPTION
## Summary
- Stop restricting ERP ship-to address mapping to `address_name === TEMP` only
- Forward `address_1`–`address_3`, city, state, zip, country, and phone whenever `address_name` is present
- Ensures orders using master ship-tos like `MAIN`/`SAME` can include the selected address in the FACTS create-order payload
## Context
Web orders were arriving in FACTS with `ShipToNumber` set (including `TEMP`) but blank ship-to address fields. Part of the cause was backend logic that only copied address lines for temporary ship-tos.
