### PR TITLE
Release product code when archiving so imports can create

### DIFF
--- a/src/Http/Controllers/Admin/ProductCrudController.php
+++ b/src/Http/Controllers/Admin/ProductCrudController.php
@@ -268,9 +268,16 @@ class ProductCrudController extends BackpackCustomCrudController
     {
         // CRUD::hasAccessOrFail('archive');
         $selectedItems = $request->input('entries');
-        if (! empty($selectedItems)) {
-            return Product::whereIn('id', $selectedItems)->where('status', '!=', 'archived')->update(['status' => 'archived']);
+        if (empty($selectedItems)) {
+            return;
         }
+
+        Product::query()
+            ->whereIn('id', $selectedItems)
+            ->where('status', '!=', 'archived')
+            ->each(fn (Product $product) => $product->archiveAndReleaseCode());
+
+        return true;
     }
 
     /**
@@ -1385,36 +1392,40 @@ class ProductCrudController extends BackpackCustomCrudController
 
     public function statusUpdate(Product $product, $status, $previous_status): RedirectResponse
     {
+        if ($status === 'archived') {
+            $product->archiveAndReleaseCode($previous_status);
+
+            return $this->flashStatusUpdate('Product status updated');
+        }
+
         $product->published_at = $status === 'published' ? now() : null;
-        $product->archived_at = $status === 'archived' ? now() : null;
+        $product->archived_at = null;
         $product->previous_status = $previous_status;
         $product->status = $status;
+        $product->product_code = explode('-archived-', $product->product_code)[0];
 
-        $product_code = explode('-archived-', $product->product_code)[0];
+        $codeTaken = Product::query()
+            ->where('product_code', $product->product_code)
+            ->when(
+                config('amplify.pim.use_product_code_unique_check', true),
+                fn ($query) => $query->where('id', '!=', $product->id)
+            )
+            ->exists();
 
-        switch ($status) {
-            case 'archived':
-                $lastProduct = Product::where('product_code', 'like', $product_code.'-archived-'.'%')->latest()->first();
-                $serial = $lastProduct ? explode('-archived-', $lastProduct->product_code)[1] : 0;
-                $product->product_code = $product_code.'-archived-'.($serial + 1);
-                break;
-            default:
-                $product->product_code = $product_code;
-                $existingProduct = Product::where('product_code', $product->product_code)
-                    ->when(config('amplify.pim.use_product_code_unique_check', true), function ($query) use ($product) {
-                        $query->where('id', '!=', $product->id);
-                    })
-                    ->first();
-                if ($existingProduct) {
-                    Alert::warning('Product code already exists')->flash();
+        if ($codeTaken) {
+            Alert::warning('Product code already exists')->flash();
 
-                    return Redirect::route('product.index');
-                }
+            return Redirect::route('product.index');
         }
 
         $product->save();
 
-        Alert::success('Product status updated')->flash();
+        return $this->flashStatusUpdate('Product status updated');
+    }
+
+    private function flashStatusUpdate(string $message): RedirectResponse
+    {
+        Alert::success($message)->flash();
 
         return Redirect::route('product.index');
     }

--- a/src/Http/Controllers/Admin/ProductCrudController.php
+++ b/src/Http/Controllers/Admin/ProductCrudController.php
@@ -272,8 +272,7 @@ class ProductCrudController extends BackpackCustomCrudController
             return;
         }
 
-        Product::query()
-            ->whereIn('id', $selectedItems)
+        Product::whereIn('id', $selectedItems)
             ->where('status', '!=', 'archived')
             ->each(fn (Product $product) => $product->archiveAndReleaseCode());
 
@@ -1404,11 +1403,10 @@ class ProductCrudController extends BackpackCustomCrudController
         $product->status = $status;
         $product->product_code = explode('-archived-', $product->product_code)[0];
 
-        $codeTaken = Product::query()
-            ->where('product_code', $product->product_code)
+        $codeTaken = Product::where('product_code', $product->product_code)
             ->when(
                 config('amplify.pim.use_product_code_unique_check', true),
-                fn ($query) => $query->where('id', '!=', $product->id)
+                fn ($query) => $query->whereKeyNot($product->id)
             )
             ->exists();
 

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -258,16 +258,11 @@ class Product extends Model implements ContractsAuditable
 
     private function nextArchivedProductCode(string $archivedPrefix): string
     {
-        $latestArchivedCode = static::query()
-            ->where('product_code', 'like', $archivedPrefix.'%')
-            ->orderByDesc('id')
+        $latestArchivedCode = static::where('product_code', 'like', $archivedPrefix.'%')
+            ->latest('id')
             ->value('product_code');
 
-        $serial = 0;
-        if (is_string($latestArchivedCode)) {
-            $suffix = explode('-archived-', $latestArchivedCode)[1] ?? '0';
-            $serial = (int) $suffix;
-        }
+        $serial = (int) (explode('-archived-', (string) $latestArchivedCode)[1] ?? 0);
 
         return $archivedPrefix.($serial + 1);
     }

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -233,6 +233,45 @@ class Product extends Model implements ContractsAuditable
         }
     }
 
+    /**
+     * Archive this product and suffix product_code so the original code can be reused.
+     */
+    public function archiveAndReleaseCode(?string $previousStatus = null): void
+    {
+        $baseCode = explode('-archived-', (string) $this->product_code)[0];
+        $archivedPrefix = $baseCode.'-archived-';
+
+        if ($this->status === 'archived' && str_starts_with((string) $this->product_code, $archivedPrefix)) {
+            return;
+        }
+
+        if ($this->status !== 'archived') {
+            $this->previous_status = $previousStatus ?? $this->status;
+        }
+
+        $this->status = 'archived';
+        $this->published_at = null;
+        $this->archived_at = now();
+        $this->product_code = $this->nextArchivedProductCode($archivedPrefix);
+        $this->save();
+    }
+
+    private function nextArchivedProductCode(string $archivedPrefix): string
+    {
+        $latestArchivedCode = static::query()
+            ->where('product_code', 'like', $archivedPrefix.'%')
+            ->orderByDesc('id')
+            ->value('product_code');
+
+        $serial = 0;
+        if (is_string($latestArchivedCode)) {
+            $suffix = explode('-archived-', $latestArchivedCode)[1] ?? '0';
+            $serial = (int) $suffix;
+        }
+
+        return $archivedPrefix.($serial + 1);
+    }
+
     protected static function booted()
     {
         static::addGlobalScope(new DatabaseScope);


### PR DESCRIPTION
## Summary
- Bulk Archive now frees `product_code` the same way the single Archive action does (`CODE-archived-N`).
- Extract `Product::archiveAndReleaseCode()` so archive suffixing lives in one place.
- Restore-from-archive still blocks if the original product code is already in use.
